### PR TITLE
Add support for br encoding decompression

### DIFF
--- a/httpreplay/cobweb.py
+++ b/httpreplay/cobweb.py
@@ -8,6 +8,7 @@ import dpkt
 import logging
 import re
 import zlib
+import brotli
 
 from httpreplay.exceptions import UnknownHttpEncoding
 from httpreplay.shoddy import Protocol
@@ -100,12 +101,17 @@ def decode_identity(ts, content):
     """Identity encoding, an encoding that doesn't change the content."""
     return content
 
+def decode_br(ts, content):
+    """ Decompress br encoded content, using the brotli algorithm"""
+    return brotli.decompress(content)
+
 content_encodings = {
     "gzip": decode_gzip,
     "deflate": decode_deflate,
     "pack200-gzip": decode_pack200_gzip,
     "none": decode_none,
     "identity": decode_identity,
+    "br": decode_br,
 }
 
 class _Response(object):

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "dpkt==1.8.7",
         "tlslite-ng==0.6.0",
         "click>=6.6, <7",
+        "brotli==1.0.7",
     ],
     extras_require={
         "mitmproxy": [
@@ -26,7 +27,7 @@ setup(
         ],
         "dev": [
             "pytest>=2.9.1"
-        ]
+        ],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Hi,
Regarding the issue https://github.com/hatching/httpreplay/issues/23, I propose you this version to decompress any encoded br data in requests.
I tested on my side and it works successfully.
