### PR TITLE
Skip faulty tls sids/keys

### DIFF
--- a/httpreplay/misc.py
+++ b/httpreplay/misc.py
@@ -16,7 +16,12 @@ def read_tlsmaster(filepath):
         if x:
             sid = x.group("sid").strip()
             key = x.group("key").strip()
-            ret[sid.decode("hex")] = key.decode("hex")
+            try:
+                # In case a malformed session or key is read. Handles the
+                # odd-length string error.
+                ret[sid.decode("hex")] = key.decode("hex")
+            except TypeError:
+                continue
     return ret
 
 class JA3(object):


### PR DESCRIPTION
A malformed hex string sometimes causes a TypeError. In this case the entire read will fail. The PR ensures the malformed hex is skipped.